### PR TITLE
Cache devbox cli, avoid github api rate limit

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -35,7 +35,7 @@ jobs:
       - name: Install devbox
         uses: ./
         with:
-          devbox-version: '0.2.0'
+          devbox-version: '0.2.2'
           project-path: 'testdata'
 
   test-action-with-cache:

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ jobs:
 | -------------- | ------------------------------------------------------------------- | --------------------- |
 | project-path   | Path to the folder that contains a valid `devbox.json`              | repo's root directory |
 | enable-cache   | Cache the entire Nix store in github based on your `devbox.json`    | false                 |
-| devbox-version | Specify devbox CLI version you want to pin to. Only supports >0.2.0 | latest                |
+| devbox-version | Specify devbox CLI version you want to pin to. Only supports >0.2.2 | latest                |
 
 ### Example Configuration
 
@@ -47,5 +47,5 @@ Here's an example job with all three inputs:
   with:
     project-path: 'path-to-folder'
     enable-cache: true
-    devbox-version: '0.2.0'
+    devbox-version: '0.2.2'
 ```

--- a/README.md
+++ b/README.md
@@ -1,26 +1,28 @@
 # devbox-install-action
+
 This action downloads the devbox CLI and installs the Nix packages defined in your `devbox.json`.
 
 [![version](https://img.shields.io/github/v/release/jetpack-io/devbox-install-action?color=green&label=version&sort=semver)](https://github.com/jetpack-io/devbox-install-action/releases) [![tests](https://github.com/jetpack-io/devbox-install-action/actions/workflows/test.yaml/badge.svg)](https://github.com/jetpack-io/devbox-install-action/actions/workflows/test.yaml?branch=main)
 
 ## Example Workflow
+
 ```
 name: Testing with devbox
 
 on: push
-  
+
 jobs:
   test:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
- 
+
       - name: Install devbox
         uses: jetpack-io/devbox-install-action@v0.1.0
-  
+
       - name: Run arbitrary commands
         run: devbox shell -- echo "done!"
- 
+
       - name: Run a script called test
         run: devbox run test
 ```
@@ -28,14 +30,17 @@ jobs:
 ## Configure Action
 
 ### Action Inputs
-| Input argument | description | default |
-| -------------- | ----------- | ------- |
-| project-path | Path to the folder that contains a valid `devbox.json` | repo's root directory |
-| enable-cache | Cache the entire Nix store in github based on your `devbox.json` | false |
-| devbox-version | Specify devbox CLI version you want to pin to | latest |
+
+| Input argument | description                                                         | default               |
+| -------------- | ------------------------------------------------------------------- | --------------------- |
+| project-path   | Path to the folder that contains a valid `devbox.json`              | repo's root directory |
+| enable-cache   | Cache the entire Nix store in github based on your `devbox.json`    | false                 |
+| devbox-version | Specify devbox CLI version you want to pin to. Only supports >0.2.0 | latest                |
 
 ### Example Configuration
+
 Here's an example job with all three inputs:
+
 ```
 - name: Install devbox
   uses: jetpack-io/devbox-install-action@v0.1.0
@@ -44,4 +49,3 @@ Here's an example job with all three inputs:
     enable-cache: true
     devbox-version: '0.2.0'
 ```
-

--- a/action.yml
+++ b/action.yml
@@ -81,6 +81,4 @@ runs:
       run: |
         NIX_INSTALLER_NO_CHANNEL_ADD=1
         NIX_BUILD_SHELL=/bin/bash
-        devbox shell --config=${{ inputs.project-path }} -- echo "Installing nix..." || true
-        source /home/runner/.nix-profile/etc/profile.d/nix.sh
-        devbox shell --config=${{ inputs.project-path }} -- echo "Installing packages..."
+        devbox shell --config=${{ inputs.project-path }} -- echo "Packages installed!"

--- a/action.yml
+++ b/action.yml
@@ -18,11 +18,6 @@ inputs:
 runs:
   using: "composite"
   steps:
-    - name: Install devbox
-      shell: bash
-      run: |
-        curl -fsSL https://get.jetpack.io/devbox | FORCE=1 bash
-  
     - name: Workaround for permission issue
       if: inputs.enable-cache == 'true'
       shell: bash
@@ -39,24 +34,53 @@ runs:
           /nix/var/nix
         key: ${{ runner.os }}-devbox-${{ hashFiles(format('{0}/devbox.json', inputs.project-path)) }}
 
-    - name: devbox version
-      id: devbox-version
-      if: inputs.devbox-version == ''
-      uses: pozetroninc/github-action-get-latest-release@v0.5.0
-      with:
-        repository: jetpack-io/devbox
-        excludes: prerelease, draft
-
-    - name: Install nix and devbox packages
+    - name: Get devbox version
       shell: bash
       env:
         DEVBOX_USE_VERSION: ${{ inputs.devbox-version }}
       run: |
+        if [[ -n $DEVBOX_USE_VERSION ]]; then
+          echo "latest_version=$DEVBOX_USE_VERSION" >> $GITHUB_ENV
+        else
+          tmp_file=$(mktemp)
+          latest_url="https://releases.jetpack.io/devbox/latest/version"
+          curl --fail --silent --location --output "${tmp_file}" "${latest_url}"
+          latest_version=$(cat "${tmp_file}")
+          if [[ -n ${latest_version} ]]; then
+            echo "Found devbox latest version ${latest_version}."
+            echo "latest_version=$latest_version" >> $GITHUB_ENV
+          else
+            echo "ERROR: unable to find the latest devbox version."
+            exit 1
+          fi
+        fi
+
+    - name: Mount devbox cli cache
+      id: cache-devbox-cli
+      uses: actions/cache@v3
+      with:
+        path: /usr/local/bin/devbox
+        key: ${{ runner.os }}-devbox-${{ env.latest_version }}
+
+    - name: Install devbox cli
+      if: steps.cache-devbox-cli.outputs.cache-hit != 'true'
+      shell: bash
+      run: |
+        DEVBOX_USE_VERSION="${{ env.latest_version }}"
+        curl -fsSL https://get.jetpack.io/devbox | FORCE=1 bash
+
+        version=$(devbox version)
+        if [[ ! "$version" = "$DEVBOX_USE_VERSION" ]]; then
+          echo "ERROR: mismatch devbox version downloaded. Expected $DEVBOX_USE_VERSION, got $version."
+          exit 1
+        fi
+        sudo mv ${HOME}/.cache/devbox/bin/${version}_*/devbox /usr/local/bin/devbox
+
+    - name: Install nix and devbox packages
+      shell: bash
+      run: |
         NIX_INSTALLER_NO_CHANNEL_ADD=1
         NIX_BUILD_SHELL=/bin/bash
-        if [[ ! -n $DEVBOX_USE_VERSION ]]; then
-          DEVBOX_USE_VERSION=${{ steps.devbox-version.outputs.release }}
-        fi
         devbox shell --config=${{ inputs.project-path }} -- echo "Installing nix..." || true
         source /home/runner/.nix-profile/etc/profile.d/nix.sh
         devbox shell --config=${{ inputs.project-path }} -- echo "Installing packages..."


### PR DESCRIPTION
This PR does the following:
- Enable caching for devbox cli
- Enable caching for nix store
- Avoid github api rate limit on getting latest release
- Bump devbox cli version to 0.2.2 in CICD