### PR TITLE
Add SHA256 checksum to install action.

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -56,6 +56,7 @@ jobs:
         uses: ./
         with:
           devbox-version: 0.5.5
+          project-path: 'testdata'
           sha256-checksum: 'd5e623c032d38250346301040d51bcdca8e6db051c3688cc452e0dda5d95a070'
 
   test-action-with-sha256-checksum-failure:
@@ -69,12 +70,13 @@ jobs:
         with:
           devbox-version: 0.5.5
           sha256-checksum: 'bad-sha'
+          project-path: 'testdata'
       - name: Fail on success
         if: steps.install-devbox.outcome == 'success'
         run: echo "The SHA check should have failed!" && exit 1
 
   test-action-with-sha256-checksum-on-mac:
-    runs-on: macos-12-xl
+    runs-on: macos-latest
     steps:
       - uses: actions/checkout@v3
       - name: Install devbox
@@ -82,3 +84,4 @@ jobs:
         with:
           devbox-version: 0.5.5
           sha256-checksum: 'd5e623c032d38250346301040d51bcdca8e6db051c3688cc452e0dda5d95a070'
+          project-path: 'testdata'

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -83,5 +83,5 @@ jobs:
         uses: ./
         with:
           devbox-version: 0.5.5
-          sha256-checksum: 'd5e623c032d38250346301040d51bcdca8e6db051c3688cc452e0dda5d95a070'
+          sha256-checksum: '3c2ce11638e3ffcd55881ec20143c38feeb24069ccdb5edf82b343c168aaca32'
           project-path: 'testdata'

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -56,6 +56,7 @@ jobs:
         uses: ./
         with:
           devbox-version: 0.5.5
+          enable-cli-cache: 'false'
           project-path: 'testdata'
           sha256-checksum: 'd5e623c032d38250346301040d51bcdca8e6db051c3688cc452e0dda5d95a070'
 
@@ -69,6 +70,7 @@ jobs:
         continue-on-error: true
         with:
           devbox-version: 0.5.5
+          enable-cli-cache: 'false'
           sha256-checksum: 'bad-sha'
           project-path: 'testdata'
       - name: Fail on success
@@ -83,5 +85,6 @@ jobs:
         uses: ./
         with:
           devbox-version: 0.5.5
+          enable-cli-cache: false
           sha256-checksum: '3c2ce11638e3ffcd55881ec20143c38feeb24069ccdb5edf82b343c168aaca32'
           project-path: 'testdata'

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -47,3 +47,14 @@ jobs:
         with:
           enable-cache: true
           project-path: 'testdata'
+
+  test-action-with-sha256-checksum:
+    #runs-on: ubuntu-latest
+    runs-on: macos-12-xl
+    steps:
+      - uses: actions/checkout@v3
+      - name: Install devbox
+        uses: ./
+        with:
+          devbox-version: 0.5.5
+          sha256-checksum: 'd5e623c032d38250346301040d51bcdca8e6db051c3688cc452e0dda5d95a070'

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -56,7 +56,7 @@ jobs:
         uses: ./
         with:
           devbox-version: 0.5.5
-          enable-cli-cache: 'false'
+          refresh-cli: 'true'
           project-path: 'testdata'
           sha256-checksum: 'd5e623c032d38250346301040d51bcdca8e6db051c3688cc452e0dda5d95a070'
 
@@ -70,7 +70,7 @@ jobs:
         continue-on-error: true
         with:
           devbox-version: 0.5.5
-          enable-cli-cache: 'false'
+          refresh-cli: 'true'
           sha256-checksum: 'bad-sha'
           project-path: 'testdata'
       - name: Fail on success
@@ -85,6 +85,6 @@ jobs:
         uses: ./
         with:
           devbox-version: 0.5.5
-          enable-cli-cache: false
+          refresh-cli: 'true'
           sha256-checksum: '3c2ce11638e3ffcd55881ec20143c38feeb24069ccdb5edf82b343c168aaca32'
           project-path: 'testdata'

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -49,7 +49,31 @@ jobs:
           project-path: 'testdata'
 
   test-action-with-sha256-checksum:
-    #runs-on: ubuntu-latest
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Install devbox
+        uses: ./
+        with:
+          devbox-version: 0.5.5
+          sha256-checksum: 'd5e623c032d38250346301040d51bcdca8e6db051c3688cc452e0dda5d95a070'
+
+  test-action-with-sha256-checksum-failure:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Install devbox
+        id: install-devbox
+        uses: ./
+        continue-on-error: true
+        with:
+          devbox-version: 0.5.5
+          sha256-checksum: 'bad-sha'
+      - name: Fail on success
+        if: steps.install-devbox.outcome == 'success'
+        run: echo "The SHA check should have failed!" && exit 1
+
+  test-action-with-sha256-checksum-on-mac:
     runs-on: macos-12-xl
     steps:
       - uses: actions/checkout@v3

--- a/README.md
+++ b/README.md
@@ -31,12 +31,13 @@ jobs:
 
 ### Action Inputs
 
-| Input argument  | description                                                         | default               |
-| --------------- | ------------------------------------------------------------------- | --------------------- |
-| project-path    | Path to the folder that contains a valid `devbox.json`              | repo's root directory |
-| enable-cache    | Cache the entire Nix store in github based on your `devbox.json`    | false                 |
-| devbox-version  | Specify devbox CLI version you want to pin to. Only supports >0.2.2 | latest                |
-| sha256-checksum | Specify an explicit checksum for the devbox binary                  |                       |
+| Input argument   | description                                                         | default               |
+| ---------------- | ------------------------------------------------------------------- | --------------------- |
+| project-path     | Path to the folder that contains a valid `devbox.json`              | repo's root directory |
+| enable-cache     | Cache the entire Nix store in github based on your `devbox.json`    | false                 |
+| enable-cli-cache | Cache the CLI binary                                                | true                  |
+| devbox-version   | Specify devbox CLI version you want to pin to. Only supports >0.2.2 | latest                |
+| sha256-checksum  | Specify an explicit checksum for the devbox binary                  |                       |
 
 ### Example Configuration
 
@@ -48,6 +49,7 @@ Here's an example job with all inputs:
   with:
     project-path: 'path-to-folder'
     enable-cache: true
+    enable-cli-cache: true
     devbox-version: 0.5.5
     sha256-sum: b6f7e24839de004ef2cad312f05865f77a73b1e0b1757e0f4d39a5911adabd50
 ```

--- a/README.md
+++ b/README.md
@@ -31,15 +31,16 @@ jobs:
 
 ### Action Inputs
 
-| Input argument | description                                                         | default               |
-| -------------- | ------------------------------------------------------------------- | --------------------- |
-| project-path   | Path to the folder that contains a valid `devbox.json`              | repo's root directory |
-| enable-cache   | Cache the entire Nix store in github based on your `devbox.json`    | false                 |
-| devbox-version | Specify devbox CLI version you want to pin to. Only supports >0.2.2 | latest                |
+| Input argument  | description                                                         | default               |
+| --------------- | ------------------------------------------------------------------- | --------------------- |
+| project-path    | Path to the folder that contains a valid `devbox.json`              | repo's root directory |
+| enable-cache    | Cache the entire Nix store in github based on your `devbox.json`    | false                 |
+| devbox-version  | Specify devbox CLI version you want to pin to. Only supports >0.2.2 | latest                |
+| sha256-checksum | Specify an explicit checksum for the devbox binary                  |                       |
 
 ### Example Configuration
 
-Here's an example job with all three inputs:
+Here's an example job with all inputs:
 
 ```
 - name: Install devbox
@@ -47,4 +48,6 @@ Here's an example job with all three inputs:
   with:
     project-path: 'path-to-folder'
     enable-cache: true
+    devbox-version: 0.5.5
+    sha256-sum: b6f7e24839de004ef2cad312f05865f77a73b1e0b1757e0f4d39a5911adabd50
 ```

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ jobs:
 | ---------------- | ------------------------------------------------------------------- | --------------------- |
 | project-path     | Path to the folder that contains a valid `devbox.json`              | repo's root directory |
 | enable-cache     | Cache the entire Nix store in github based on your `devbox.json`    | false                 |
-| enable-cli-cache | Cache the CLI binary                                                | true                  |
+| refresh-cli      | Specify whether the CLI should be redownloaded                      | false                 |
 | devbox-version   | Specify devbox CLI version you want to pin to. Only supports >0.2.2 | latest                |
 | sha256-checksum  | Specify an explicit checksum for the devbox binary                  |                       |
 
@@ -48,8 +48,8 @@ Here's an example job with all inputs:
   uses: jetpack-io/devbox-install-action@v0.3.0
   with:
     project-path: 'path-to-folder'
-    enable-cache: true
-    enable-cli-cache: true
+    enable-cache: 'true'
+    refresh-cli: 'false'
     devbox-version: 0.5.5
     sha256-sum: b6f7e24839de004ef2cad312f05865f77a73b1e0b1757e0f4d39a5911adabd50
 ```

--- a/action.yml
+++ b/action.yml
@@ -11,9 +11,9 @@ inputs:
   enable-cache:  # 'true' or 'false'
     description: 'Caching the entire Nix store in github based on your devbox.json'
     default: 'false'
-  enable-cli-cache: # 'true' or 'false'
-    description: 'Caching the CLI binary'
-    default: 'true'
+  refresh-cli: # 'true' or 'false'
+    description: 'Specify whether the CLI should be redownloaded'
+    default: 'false'
   devbox-version: # version of the devbox cli
     description: 'Specify devbox CLI version you want to pin to. Default to latest'
     default: ''
@@ -61,7 +61,7 @@ runs:
         fi
 
     - name: Mount devbox cli cache
-      if: inputs.enable-cli-cache == 'true'
+      if: inputs.refresh-cli == 'false'
       id: cache-devbox-cli
       uses: actions/cache@v3
       with:

--- a/action.yml
+++ b/action.yml
@@ -14,6 +14,8 @@ inputs:
   devbox-version: # version of the devbox cli
     description: 'Specify devbox CLI version you want to pin to. Default to latest'
     default: ''
+  sha256-checksum: # the expected SHA256 checksum of the devbox binary.
+    description: 'Specify an explicit checksum for the devbox binary. For extra security on top of the existing checks in the devbox launch script'
 
 runs:
   using: "composite"
@@ -65,6 +67,8 @@ runs:
     - name: Install devbox cli
       if: steps.cache-devbox-cli.outputs.cache-hit != 'true'
       shell: bash
+      env:
+        DEVBOX_SHA256: ${{ inputs.sha256-checksum}}
       run: |
         export DEVBOX_USE_VERSION="${{ env.latest_version }}"
         curl -fsSL https://get.jetpack.io/devbox | FORCE=1 bash
@@ -74,7 +78,25 @@ runs:
           echo "ERROR: mismatch devbox version downloaded. Expected $DEVBOX_USE_VERSION, got $version."
           exit 1
         fi
-        sudo mv ${HOME}/.cache/devbox/bin/${version}_*/devbox /usr/local/bin/devbox
+        DEVBOX_BINARY="$(find "${HOME}/.cache/devbox/bin" -name devbox)"
+        if [ -n "$DEVBOX_SHA256" ]; then
+          if command -v "sha256sum" 1>/dev/null 2>&1; then
+            DEVBOX_CHECKSUM="$(sha256sum "$DEVBOX_BINARY" | cut -f1 -d' ')"
+          elif command -v "shasum" 1>/dev/null 2>&1; then
+            DEVBOX_CHECKSUM="$(shasum -a 256 "$DEVBOX_BINARY" | cut -f1 -d' ')"
+          fi
+
+          if [ -z "$DEVBOX_CHECKSUM" ]; then
+            echo "ERROR: unable to get devbox checksum. Please ensure sha256sum or shasum is installed."
+            exit 2
+          fi
+
+          if [[ ! "$DEVBOX_CHECKSUM" = "$DEVBOX_SHA256" ]]; then
+            echo "ERROR: checksums do not match. Expected $DEVBOX_SHA256, got $DEVBOX_CHECKSUM."
+            exit 3
+          fi
+        fi
+        sudo mv "$DEVBOX_BINARY" /usr/local/bin/devbox
 
     - name: Install nix and devbox packages
       shell: bash

--- a/action.yml
+++ b/action.yml
@@ -11,6 +11,9 @@ inputs:
   enable-cache:  # 'true' or 'false'
     description: 'Caching the entire Nix store in github based on your devbox.json'
     default: 'false'
+  enable-cli-cache: # 'true' or 'false'
+    description: 'Caching the CLI binary'
+    default: 'true'
   devbox-version: # version of the devbox cli
     description: 'Specify devbox CLI version you want to pin to. Default to latest'
     default: ''
@@ -58,6 +61,7 @@ runs:
         fi
 
     - name: Mount devbox cli cache
+      if: inputs.enable-cli-cache == 'true'
       id: cache-devbox-cli
       uses: actions/cache@v3
       with:
@@ -80,7 +84,6 @@ runs:
         fi
         DEVBOX_BINARY="$(find "${HOME}/.cache/devbox/bin" -name devbox)"
         if [ -n "$DEVBOX_SHA256" ]; then
-          echo "Found sha: $DEVBOX_SHA256" # Delete this.
           if command -v "sha256sum" 1>/dev/null 2>&1; then
             # Linux distributions will likely have this.
             DEVBOX_CHECKSUM="$(sha256sum "$DEVBOX_BINARY" | cut -f1 -d' ')"

--- a/action.yml
+++ b/action.yml
@@ -81,8 +81,10 @@ runs:
         DEVBOX_BINARY="$(find "${HOME}/.cache/devbox/bin" -name devbox)"
         if [ -n "$DEVBOX_SHA256" ]; then
           if command -v "sha256sum" 1>/dev/null 2>&1; then
+            # Linux distributions will likely have this.
             DEVBOX_CHECKSUM="$(sha256sum "$DEVBOX_BINARY" | cut -f1 -d' ')"
           elif command -v "shasum" 1>/dev/null 2>&1; then
+            # MacOS comes with this.
             DEVBOX_CHECKSUM="$(shasum -a 256 "$DEVBOX_BINARY" | cut -f1 -d' ')"
           fi
 

--- a/action.yml
+++ b/action.yml
@@ -45,7 +45,7 @@ runs:
           echo "latest_version=$DEVBOX_USE_VERSION" >> $GITHUB_ENV
         else
           tmp_file=$(mktemp)
-          latest_url="https://releases.jetpack.io/devbox/latest/version"
+          latest_url="https://releases.jetpack.io/devbox/stable/version"
           curl --fail --silent --location --output "${tmp_file}" "${latest_url}"
           latest_version=$(cat "${tmp_file}")
           if [[ -n ${latest_version} ]]; then
@@ -68,7 +68,7 @@ runs:
       if: steps.cache-devbox-cli.outputs.cache-hit != 'true'
       shell: bash
       env:
-        DEVBOX_SHA256: ${{ inputs.sha256-checksum}}
+        DEVBOX_SHA256: ${{ inputs.sha256-checksum }}
       run: |
         export DEVBOX_USE_VERSION="${{ env.latest_version }}"
         curl -fsSL https://get.jetpack.io/devbox | FORCE=1 bash
@@ -80,6 +80,7 @@ runs:
         fi
         DEVBOX_BINARY="$(find "${HOME}/.cache/devbox/bin" -name devbox)"
         if [ -n "$DEVBOX_SHA256" ]; then
+          echo "Found sha: $DEVBOX_SHA256" # Delete this.
           if command -v "sha256sum" 1>/dev/null 2>&1; then
             # Linux distributions will likely have this.
             DEVBOX_CHECKSUM="$(sha256sum "$DEVBOX_BINARY" | cut -f1 -d' ')"


### PR DESCRIPTION
The install action now supports a sha256 checksum of the resulting binary. In the event that jetpack's devbox install script is compromised, this will allow users to double check that the resulting binary has a checksum configured at the github action level, potentially preventing a breach of CI infrastructure.