### PR TITLE
Update installer action to match the latest cli behavior

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -8,6 +8,8 @@ concurrency:
 on:
   pull_request:
   push:
+    branches:
+      - main
     paths-ignore:
       - '**.md'
 
@@ -35,7 +37,7 @@ jobs:
       - name: Install devbox
         uses: ./
         with:
-          devbox-version: 0.4.4
+          devbox-version: 0.5.5
           project-path: 'testdata'
 
   test-action-with-cache:
@@ -56,7 +58,7 @@ jobs:
         uses: ./
         with:
           devbox-version: 0.5.5
-          refresh-cli: 'true'
+          refresh-cli: true
           project-path: 'testdata'
           sha256-checksum: 'd5e623c032d38250346301040d51bcdca8e6db051c3688cc452e0dda5d95a070'
 
@@ -70,7 +72,7 @@ jobs:
         continue-on-error: true
         with:
           devbox-version: 0.5.5
-          refresh-cli: 'true'
+          refresh-cli: true
           sha256-checksum: 'bad-sha'
           project-path: 'testdata'
       - name: Fail on success
@@ -85,6 +87,7 @@ jobs:
         uses: ./
         with:
           devbox-version: 0.5.5
-          refresh-cli: 'true'
+          enable-cache: true
+          refresh-cli: true
           sha256-checksum: '3c2ce11638e3ffcd55881ec20143c38feeb24069ccdb5edf82b343c168aaca32'
           project-path: 'testdata'

--- a/action.yml
+++ b/action.yml
@@ -24,7 +24,7 @@ runs:
   using: "composite"
   steps:
     - name: Workaround for permission issue
-      if: inputs.enable-cache == 'true'
+      if: inputs.enable-cache == 'true' && runner.os != 'macOS'
       shell: bash
       run: sudo chmod u+s "$(command -v tar)"
 
@@ -37,6 +37,7 @@ runs:
           ~/.nix-profile
           /nix/store
           /nix/var/nix
+          ~/.local/state/nix
         key: ${{ runner.os }}-devbox-${{ hashFiles(format('{0}/devbox.json', inputs.project-path)) }}
 
     - name: Get devbox version

--- a/testdata/devbox.json
+++ b/testdata/devbox.json
@@ -1,11 +1,8 @@
 {
   "packages": [
-    "go"
+    "go@latest"
   ],
   "shell": {
     "init_hook": null
-  },
-  "nixpkgs": {
-    "commit": "52e3e80afff4b16ccb7c52e9f0f5220552f03d04"
   }
 }


### PR DESCRIPTION
## Summary
- Update test version to 0.5.5
- Update macos test to use cache for speed
- Add new nix installation location for caching, where this logic was introduced in https://github.com/NixOS/nix/pull/5588/files and it uses XDG directory