### PR TITLE
feat: Configure nix access token to prevent GitHub rate limiting

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -29,6 +29,7 @@ jobs:
         uses: ./
         with:
           project-path: 'testdata'
+          disable-nix-access-token: "${{ github.ref != 'refs/heads/main' }}"
 
   test-action-with-version:
     runs-on: ubuntu-latest
@@ -39,6 +40,7 @@ jobs:
         with:
           devbox-version: 0.5.5
           project-path: 'testdata'
+          disable-nix-access-token: "${{ github.ref != 'refs/heads/main' }}"
 
   test-action-with-cache:
     runs-on: ubuntu-latest
@@ -49,6 +51,7 @@ jobs:
         with:
           enable-cache: true
           project-path: 'testdata'
+          disable-nix-access-token: "${{ github.ref != 'refs/heads/main' }}"
 
   test-action-with-sha256-checksum:
     runs-on: ubuntu-latest
@@ -61,6 +64,7 @@ jobs:
           refresh-cli: true
           project-path: 'testdata'
           sha256-checksum: 'd5e623c032d38250346301040d51bcdca8e6db051c3688cc452e0dda5d95a070'
+          disable-nix-access-token: "${{ github.ref != 'refs/heads/main' }}"
 
   test-action-with-sha256-checksum-failure:
     runs-on: ubuntu-latest
@@ -75,6 +79,7 @@ jobs:
           refresh-cli: true
           sha256-checksum: 'bad-sha'
           project-path: 'testdata'
+          disable-nix-access-token: "${{ github.ref != 'refs/heads/main' }}"
       - name: Fail on success
         if: steps.install-devbox.outcome == 'success'
         run: echo "The SHA check should have failed!" && exit 1
@@ -91,3 +96,4 @@ jobs:
           refresh-cli: true
           sha256-checksum: '3c2ce11638e3ffcd55881ec20143c38feeb24069ccdb5edf82b343c168aaca32'
           project-path: 'testdata'
+          disable-nix-access-token: "${{ github.ref != 'refs/heads/main' }}"

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ jobs:
         uses: jetpack-io/devbox-install-action@v0.4.0
 
       - name: Run arbitrary commands
-        run: devbox shell -- echo "done!"
+        run: devbox run -- echo "done!"
 
       - name: Run a script called test
         run: devbox run test
@@ -31,13 +31,14 @@ jobs:
 
 ### Action Inputs
 
-| Input argument   | description                                                         | default               |
-| ---------------- | ------------------------------------------------------------------- | --------------------- |
-| project-path     | Path to the folder that contains a valid `devbox.json`              | repo's root directory |
-| enable-cache     | Cache the entire Nix store in github based on your `devbox.json`    | false                 |
-| refresh-cli      | Specify whether the CLI should be redownloaded                      | false                 |
-| devbox-version   | Specify devbox CLI version you want to pin to. Only supports >0.2.2 | latest                |
-| sha256-checksum  | Specify an explicit checksum for the devbox binary                  |                       |
+| Input argument           | description                                                                           | default               |
+| ----------------         | ------------------------------------------------------------------------------------- | --------------------- |
+| project-path             | Path to the folder that contains a valid `devbox.json`                                | repo's root directory |
+| enable-cache             | Cache the entire Nix store in github based on your `devbox.json`                      | false                 |
+| refresh-cli              | Specify whether the CLI should be redownloaded                                        | false                 |
+| devbox-version           | Specify devbox CLI version you want to pin to. Only supports >0.2.2                   | latest                |
+| sha256-checksum          | Specify an explicit checksum for the devbox binary                                    |                       |
+| disable-nix-access-token | Disable configuration of nix access-tokens with the GitHub token used in the workflow | false                 |
 
 ### Example Configuration
 

--- a/action.yml
+++ b/action.yml
@@ -19,6 +19,9 @@ inputs:
     default: ''
   sha256-checksum: # the expected SHA256 checksum of the devbox binary.
     description: 'Specify an explicit checksum for the devbox binary. For extra security on top of the existing checks in the devbox launch script'
+  configure-nix-access-token: # 'true' or 'false'
+    description: 'Specify whether the nix access-tokens should be configured with the GitHub token used in the workflow'
+    default: 'true'
 
 runs:
   using: "composite"
@@ -104,6 +107,13 @@ runs:
           fi
         fi
         sudo mv "$DEVBOX_BINARY" /usr/local/bin/devbox
+
+    - name: Configure nix access-tokens
+      if: inputs.configure-nix-access-token == 'true'
+      shell: bash
+      run: |
+        mkdir -p ~/.config/nix
+        echo "access-tokens = github.com=${{ secrets.GITHUB_TOKEN }}" >> ~/.config/nix/nix.conf
 
     - name: Install nix and devbox packages
       shell: bash

--- a/action.yml
+++ b/action.yml
@@ -19,9 +19,9 @@ inputs:
     default: ''
   sha256-checksum: # the expected SHA256 checksum of the devbox binary.
     description: 'Specify an explicit checksum for the devbox binary. For extra security on top of the existing checks in the devbox launch script'
-  configure-nix-access-token: # 'true' or 'false'
-    description: 'Specify whether the nix access-tokens should be configured with the GitHub token used in the workflow'
-    default: 'true'
+  disable-nix-access-token: # 'true' or 'false'
+    description: 'Disable configuration of nix access-tokens with the GitHub token used in the workflow'
+    default: 'false'
 
 runs:
   using: "composite"
@@ -109,11 +109,11 @@ runs:
         sudo mv "$DEVBOX_BINARY" /usr/local/bin/devbox
 
     - name: Configure nix access-tokens
-      if: inputs.configure-nix-access-token == 'true'
+      if: inputs.disable-nix-access-token == 'false'
       shell: bash
       run: |
         mkdir -p ~/.config/nix
-        echo "access-tokens = github.com=${{ secrets.GITHUB_TOKEN }}" >> ~/.config/nix/nix.conf
+        echo "access-tokens = github.com=${{ github.token }}" >> ~/.config/nix/nix.conf
 
     - name: Install nix and devbox packages
       shell: bash


### PR DESCRIPTION
Based on the suggestion at https://github.com/jetpack-io/devbox/pull/728/files#diff-e6fe83bc13b20d4fd513659c4b2cb8c34617a4b1f04e95b390517c42e905867fR134.

I have used this as a step in my own workflows and it works but would be great if it could be included in this action.
