### PR TITLE
Fix macos caching issue

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -38,7 +38,7 @@ jobs:
       - name: Install devbox
         uses: ./
         with:
-          devbox-version: 0.5.5
+          devbox-version: 0.5.13
           project-path: 'testdata'
           disable-nix-access-token: "${{ github.ref != 'refs/heads/main' }}"
 
@@ -60,10 +60,10 @@ jobs:
       - name: Install devbox
         uses: ./
         with:
-          devbox-version: 0.5.5
+          devbox-version: 0.5.13
           refresh-cli: true
           project-path: 'testdata'
-          sha256-checksum: 'd5e623c032d38250346301040d51bcdca8e6db051c3688cc452e0dda5d95a070'
+          sha256-checksum: '481cc5d270a22843d7f7c34eac6cea4bbe9f2cdfbc72f0217ea3823ebabecc43'
           disable-nix-access-token: "${{ github.ref != 'refs/heads/main' }}"
 
   test-action-with-sha256-checksum-failure:
@@ -75,7 +75,7 @@ jobs:
         uses: ./
         continue-on-error: true
         with:
-          devbox-version: 0.5.5
+          devbox-version: 0.5.13
           refresh-cli: true
           sha256-checksum: 'bad-sha'
           project-path: 'testdata'
@@ -91,9 +91,9 @@ jobs:
       - name: Install devbox
         uses: ./
         with:
-          devbox-version: 0.5.5
+          devbox-version: 0.5.13
           enable-cache: true
           refresh-cli: true
-          sha256-checksum: '3c2ce11638e3ffcd55881ec20143c38feeb24069ccdb5edf82b343c168aaca32'
+          sha256-checksum: 'f5907e5782f6e1f5a7ca32c8ae2a0a81618549314bab237174a46fb216f43809'
           project-path: 'testdata'
           disable-nix-access-token: "${{ github.ref != 'refs/heads/main' }}"

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ jobs:
 ### Action Inputs
 
 | Input argument           | description                                                                           | default               |
-| ----------------         | ------------------------------------------------------------------------------------- | --------------------- |
+| ------------------------ | ------------------------------------------------------------------------------------- | --------------------- |
 | project-path             | Path to the folder that contains a valid `devbox.json`                                | repo's root directory |
 | enable-cache             | Cache the entire Nix store in github based on your `devbox.json`                      | false                 |
 | refresh-cli              | Specify whether the CLI should be redownloaded                                        | false                 |
@@ -51,7 +51,7 @@ Here's an example job with all inputs:
     project-path: 'path-to-folder'
     enable-cache: 'true'
     refresh-cli: 'false'
-    devbox-version: 0.5.11
+    devbox-version: 0.5.13
     disable-nix-access-token: 'false'
-    sha256-sum: b6f7e24839de004ef2cad312f05865f77a73b1e0b1757e0f4d39a5911adabd50
+    sha256-sum: f5907e5782f6e1f5a7ca32c8ae2a0a81618549314bab237174a46fb216f43809
 ```

--- a/action.yml
+++ b/action.yml
@@ -27,9 +27,14 @@ runs:
   using: "composite"
   steps:
     - name: Workaround for permission issue
-      if: inputs.enable-cache == 'true' && runner.os != 'macOS'
+      if: inputs.enable-cache == 'true'
       shell: bash
-      run: sudo chmod u+s "$(command -v tar)"
+      run: |
+        if [ "$RUNNER_OS" == "macOS" ]; then
+          sudo chmod u+s "$(command -v gtar)"
+        else
+          sudo chmod u+s "$(command -v tar)"
+        fi
 
     - name: Mount nix store cache
       if: inputs.enable-cache == 'true'
@@ -39,7 +44,6 @@ runs:
           ~/.nix-defexpr
           ~/.nix-profile
           /nix/store
-          /nix/var/nix
           ~/.local/state/nix
         key: ${{ runner.os }}-devbox-${{ hashFiles(format('{0}/devbox.lock', inputs.project-path)) }}
 
@@ -81,8 +85,6 @@ runs:
         export DEVBOX_USE_VERSION="${{ env.latest_version }}"
         curl -fsSL https://get.jetpack.io/devbox | FORCE=1 bash
 
-        devbox setup nix # temporary until 0.5.13 is released
-        
         version=$(devbox version)
         if [[ ! "$version" = "$DEVBOX_USE_VERSION" ]]; then
           echo "ERROR: mismatch devbox version downloaded. Expected $DEVBOX_USE_VERSION, got $version."
@@ -120,6 +122,7 @@ runs:
     - name: Install nix and devbox packages
       shell: bash
       run: |
-        NIX_INSTALLER_NO_CHANNEL_ADD=1
-        NIX_BUILD_SHELL=/bin/bash
+        export NIX_USER_COUNT=1
+        export NIX_INSTALLER_NO_CHANNEL_ADD=1
+        export NIX_BUILD_SHELL=/bin/bash
         devbox run --config=${{ inputs.project-path }} -- echo "Packages installed!"

--- a/action.yml
+++ b/action.yml
@@ -26,27 +26,6 @@ inputs:
 runs:
   using: "composite"
   steps:
-    - name: Workaround for permission issue
-      if: inputs.enable-cache == 'true'
-      shell: bash
-      run: |
-        if [ "$RUNNER_OS" == "macOS" ]; then
-          sudo chmod u+s "$(command -v gtar)"
-        else
-          sudo chmod u+s "$(command -v tar)"
-        fi
-
-    - name: Mount nix store cache
-      if: inputs.enable-cache == 'true'
-      uses: actions/cache@v3
-      with:
-        path: |
-          ~/.nix-defexpr
-          ~/.nix-profile
-          /nix/store
-          ~/.local/state/nix
-        key: ${{ runner.os }}-devbox-${{ hashFiles(format('{0}/devbox.lock', inputs.project-path)) }}
-
     - name: Get devbox version
       shell: bash
       env:
@@ -119,10 +98,39 @@ runs:
         mkdir -p ~/.config/nix
         echo "access-tokens = github.com=${{ github.token }}" >> ~/.config/nix/nix.conf
 
-    - name: Install nix and devbox packages
+    - name: Devbox setup Nix
       shell: bash
       run: |
         export NIX_USER_COUNT=1
         export NIX_INSTALLER_NO_CHANNEL_ADD=1
         export NIX_BUILD_SHELL=/bin/bash
+        devbox setup nix
+
+    - name: Workaround nix store cache permission issue
+      if: inputs.enable-cache == 'true'
+      shell: bash
+      run: |
+        whoami
+        ls -al /nix/store
+        if [ "$RUNNER_OS" == "macOS" ]; then
+          sudo /usr/sbin/dseditgroup -o edit -t user \
+          -a "$(whoami)" "nixbld"
+        else
+          sudo chmod u+s "$(command -v tar)"
+        fi
+
+    - name: Mount nix store cache
+      if: inputs.enable-cache == 'true'
+      uses: actions/cache@v3
+      with:
+        path: |
+          ~/.nix-defexpr
+          ~/.nix-profile
+          /nix/store
+          ~/.local/state/nix
+        key: ${{ runner.os }}-devbox-${{ hashFiles(format('{0}/devbox.lock', inputs.project-path)) }}
+
+    - name: Install devbox packages
+      shell: bash
+      run: |
         devbox run --config=${{ inputs.project-path }} -- echo "Packages installed!"

--- a/action.yml
+++ b/action.yml
@@ -98,7 +98,6 @@ runs:
         if [ "$RUNNER_OS" == "macOS" ]; then
           sudo mv /usr/local/bin/gtar /usr/local/bin/gtar.orig
           echo "#!/bin/sh" >> /usr/local/bin/gtar
-          echo "set -euo pipefail" >> /usr/local/bin/gtar
           echo 'exec sudo /usr/local/bin/gtar.orig "$@"' >> /usr/local/bin/gtar
           sudo chmod +x /usr/local/bin/gtar
         else
@@ -123,6 +122,7 @@ runs:
       uses: actions/cache@v3
       with:
         path: |
+          ~/.cache
           ~/.local/state/nix
           ~/.nix-defexpr
           ~/.nix-profile

--- a/action.yml
+++ b/action.yml
@@ -91,6 +91,20 @@ runs:
         fi
         sudo mv "$DEVBOX_BINARY" /usr/local/bin/devbox
 
+    - name: Workaround nix store cache permission issue
+      if: inputs.enable-cache == 'true'
+      shell: bash
+      run: |
+        if [ "$RUNNER_OS" == "macOS" ]; then
+          sudo mv /usr/local/bin/gtar /usr/local/bin/gtar.orig
+          echo "#!/bin/sh" >> /usr/local/bin/gtar
+          echo "set -euo pipefail" >> /usr/local/bin/gtar
+          echo 'exec sudo /usr/local/bin/gtar.orig "$@"' >> /usr/local/bin/gtar
+          sudo chmod +x /usr/local/bin/gtar
+        else
+          sudo chmod u+s "$(command -v tar)"
+        fi
+
     - name: Configure nix access-tokens
       if: inputs.disable-nix-access-token == 'false'
       shell: bash
@@ -98,36 +112,22 @@ runs:
         mkdir -p ~/.config/nix
         echo "access-tokens = github.com=${{ github.token }}" >> ~/.config/nix/nix.conf
 
-    - name: Devbox setup Nix
-      shell: bash
-      run: |
-        export NIX_USER_COUNT=1
-        export NIX_INSTALLER_NO_CHANNEL_ADD=1
-        export NIX_BUILD_SHELL=/bin/bash
-        devbox setup nix
-
-    - name: Workaround nix store cache permission issue
-      if: inputs.enable-cache == 'true'
-      shell: bash
-      run: |
-        whoami
-        ls -al /nix/store
-        if [ "$RUNNER_OS" == "macOS" ]; then
-          sudo /usr/sbin/dseditgroup -o edit -t user \
-          -a "$(whoami)" "nixbld"
-        else
-          sudo chmod u+s "$(command -v tar)"
-        fi
+    - name: Install nix
+      uses: DeterminateSystems/nix-installer-action@v4
+      with:
+        logger: pretty
+        extra-conf: experimental-features = ca-derivations fetch-closure
 
     - name: Mount nix store cache
       if: inputs.enable-cache == 'true'
       uses: actions/cache@v3
       with:
         path: |
+          ~/.local/state/nix
           ~/.nix-defexpr
           ~/.nix-profile
           /nix/store
-          ~/.local/state/nix
+          /nix/var/nix
         key: ${{ runner.os }}-devbox-${{ hashFiles(format('{0}/devbox.lock', inputs.project-path)) }}
 
     - name: Install devbox packages

--- a/testdata/devbox.lock
+++ b/testdata/devbox.lock
@@ -1,0 +1,11 @@
+{
+  "lockfile_version": "1",
+  "packages": {
+    "go@latest": {
+      "last_modified": "2023-09-17T10:54:49Z",
+      "resolved": "github:NixOS/nixpkgs/5148520bfab61f99fd25fb9ff7bfbb50dad3c9db#go_1_21",
+      "source": "devbox-search",
+      "version": "1.21.1"
+    }
+  }
+}


### PR DESCRIPTION
### Description
macOS caching is broken. This PR fixes it. This is related to `gtar` not having `sudo` permission, but `/nix/store` requires sudo. There are many many related issues out there. eg. https://github.com/actions/cache/issues/749

I also switched to using DeterminateSystems nix installer. However, I noticed that even though cache is successfully restored in the latest round of CICD, we are still fetching the binaries from remote? (at least based on the log lines) Why is that?

I suspect that I'm missing some sqlite data in the cached files. cc @savil @gcurtis if any of you have insights into this.

EDIT: SOLVED. Added xdg paths in the cache and it reduces the time by half. 🎉 🎉 🎉 

closes https://github.com/jetpack-io/devbox-install-action/issues/13