### PR TITLE
Revert "Narrow the cache of xdg directory"

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -122,8 +122,7 @@ runs:
       uses: actions/cache@v3
       with:
         path: |
-          ~/.cache/devbox
-          ~/.cache/nix
+          ~/.cache
           ~/.local/state/nix
           ~/.nix-defexpr
           ~/.nix-profile


### PR DESCRIPTION
Reverts jetpack-io/devbox-install-action#20

This results in the `~/.cache` directory gets created under `root` instead of `runner`. Reverting fix this problem.

Verified the fix with https://github.com/jetpack-io/devbox-install-action/pull/21