### PR TITLE
feat: skip-nix-install

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ jobs:
 | devbox-version           | Specify devbox CLI version you want to pin to. Only supports >0.2.2                   | latest                |
 | sha256-checksum          | Specify an explicit checksum for the devbox binary                                    |                       |
 | disable-nix-access-token | Disable configuration of nix access-tokens with the GitHub token used in the workflow | false                 |
+| skip-nix-installation    | Skip the installation of nix                                                          | false                 |
 
 ### Example Configuration
 

--- a/action.yml
+++ b/action.yml
@@ -5,10 +5,10 @@ branding:
   color: 'purple'
 
 inputs:
-  project-path:  # path to folder
+  project-path: # path to folder
     description: 'Project path to devbox.json. Default to the root directory of the repository.'
     default: '.'
-  enable-cache:  # 'true' or 'false'
+  enable-cache: # 'true' or 'false'
     description: 'Caching the entire Nix store in github based on your devbox.json'
     default: 'false'
   refresh-cli: # 'true' or 'false'
@@ -21,6 +21,9 @@ inputs:
     description: 'Specify an explicit checksum for the devbox binary. For extra security on top of the existing checks in the devbox launch script'
   disable-nix-access-token: # 'true' or 'false'
     description: 'Disable configuration of nix access-tokens with the GitHub token used in the workflow'
+    default: 'false'
+  skip-nix-installation: # 'true' or 'false'
+    description: 'Skip the installation of nix'
     default: 'false'
 
 runs:
@@ -116,6 +119,7 @@ runs:
         echo "access-tokens = github.com=${{ github.token }}" >> ~/.config/nix/nix.conf
 
     - name: Install nix
+      if: inputs.skip-nix-installation == 'false'
       uses: DeterminateSystems/nix-installer-action@v4
       with:
         logger: pretty


### PR DESCRIPTION
We have some problems in our custom runner with this action so I've tried it with skipping the installation via the included action and it works in our runners (we do not use the GitHub provided ones, we are using custom runners).

In case you are wondering which action we are using, we use: `cachix/install-nix-action@v23` - I guess it has something to do with the usage of `sudo` in the other action but I'm not 100% sure on that.
I'm also not sure about the differences between these two actions so I've opted for the possibility to skip the installation rather than changing the action as I guess you've put a lot of thought into which action to use.

Edit: I need to correct myself, it's not because of `sudo` but because of `systemd`. I tried to run the action without `systemd` by passing in `init: none` and  `planner: linux-multi` but I got other errors. So I would prefer to be able to just skip  the installation and use my own / a different action to install `nix`.