### PR TITLE
Add packages to PATH

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -11,6 +11,9 @@ inputs:
   enable-cache: # 'true' or 'false'
     description: 'Caching the entire Nix store in github based on your devbox.json'
     default: 'false'
+  enable-packages-path: # 'true' or 'false'
+    description: 'Add devbox packages to $PATH'
+    default: 'false'
   refresh-cli: # 'true' or 'false'
     description: 'Specify whether the CLI should be redownloaded'
     default: 'false'
@@ -151,6 +154,11 @@ runs:
       shell: bash
       run: |
         devbox run --config=${{ inputs.project-path }} -- echo "Packages installed!"
+
+    - name: Adding devbox packages to $PATH
+      if: inputs.enable-packages-path == 'true'
+      shell: bash
+      run: echo '.devbox/virtenv/.wrappers/bin' >> $GITHUB_PATH
 
     - name: Save nix store cache
       if: inputs.enable-cache == 'true' && steps.cache-devbox-nix-store.outputs.cache-hit != 'true'


### PR DESCRIPTION
After installing packages make them available to further steps below after installing devbox.

When using actions that rely on finding a binary on the path, you can't enable the shell or run `devbox run`, this option makes every installed binary available on your $PATH.

