### PR TITLE
Add Dependabot config for GitHub Actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,7 @@
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: "/"
+    schedule:
+      interval: weekly
+      day: monday


### PR DESCRIPTION
This will help ensure that upstream GitHub actions stay up to date.  It operationalizes updates like https://github.com/jetpack-io/devbox-install-action/pull/30 such that they're never missed.

https://docs.github.com/en/code-security/dependabot/working-with-dependabot/keeping-your-actions-up-to-date-with-dependabot

### Testing
You can see the PRs that this config will open in my fork here:

https://github.com/wadells/devbox-install-action/pulls?q=+is%3Apr+author%3Aapp%2Fdependabot+