### PR TITLE
Pin DeterminateSystems/nix-installer-action to SHA

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -127,7 +127,7 @@ runs:
 
     - name: Install nix
       if: inputs.skip-nix-installation == 'false'
-      uses: DeterminateSystems/nix-installer-action@v4
+      uses: DeterminateSystems/nix-installer-action@65d7c888b2778e8cf30a07a88422ccb23499bfb8  # v4
       with:
         logger: pretty
         extra-conf: experimental-features = ca-derivations fetch-closure


### PR DESCRIPTION
GitHub recommends pinning 3rd party actions for security and reproducibility.  This should be a familiar idea for folks who've worked with Nix. 😄

https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions#using-third-party-actions

For now, I've excluded dependencies from `actions/` as these are "2nd party" actions, developed and published by GitHub.  We have higher trust that GitHub published actions won't spuriously force push tag values, resulting in non deterministic runtime behavior.

If you'd like to pin all dependencies, let me know and I'll update this to include everything.  This will result in a higher sustaining burden, as Dependabot (https://github.com/jetpack-io/devbox-install-action/pull/31) will generate many more updates for pinned `actions/` actions.


